### PR TITLE
[FLINK-36455] Sinks retry synchronously

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -19,7 +19,11 @@
     </option>
   </component>
   <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../connect/kafka-connect-jdbc" vcs="Git" />
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../flink-connector-jdbc" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../flink-connector-kafka" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../flink-connector-kafka/tools/releasing/shared" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/docs/themes/book" vcs="Git" />
   </component>
 </project>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorStateHandler.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorStateHandler.java
@@ -175,9 +175,7 @@ public class CompactorOperatorStateHandler
                                 summary.getSubtaskId(),
                                 summary.getNumberOfSubtasks(),
                                 summary.getCheckpointIdOrEOI(),
-                                summary.getNumberOfCommittables() + results.size(),
-                                summary.getNumberOfPendingCommittables() + results.size(),
-                                summary.getNumberOfFailedCommittables())));
+                                summary.getNumberOfCommittables() + results.size())));
         for (FileSinkCommittable committable : results) {
             output.collect(
                     new StreamRecord<>(

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactorOperatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactorOperatorTest.java
@@ -98,7 +98,6 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
             // 1summary+1compacted+2cleanup
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(4);
-            results.element(0, as(committableSummary())).hasPendingCommittables(3);
             results.element(1, as(committableWithLineage()))
                     .hasCommittable(committable("0", "compacted-0", 10));
             results.element(2, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".0"));
@@ -140,7 +139,6 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
 
             ListAssert<CommittableMessage<FileSinkCommittable>> messages =
                     assertThat(harness.extractOutputValues()).hasSize(3);
-            messages.element(0, as(committableSummary())).hasPendingCommittables(2);
             messages.element(1, as(committableWithLineage()))
                     .hasCommittable(cleanupInprogressRequest);
             messages.element(2, as(committableWithLineage())).hasCommittable(cleanupPathRequest);
@@ -207,13 +205,13 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
             // 1summary+1compacted+2cleanup * 2
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(8);
-            results.element(0, as(committableSummary())).hasPendingCommittables(3);
+            results.element(0, as(committableSummary()));
             results.element(1, as(committableWithLineage()))
                     .hasCommittable(committable("0", "compacted-0", 10));
             results.element(2, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".0"));
             results.element(3, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".1"));
 
-            results.element(4, as(committableSummary())).hasPendingCommittables(3);
+            results.element(4, as(committableSummary()));
             results.element(5, as(committableWithLineage()))
                     .hasCommittable(committable("0", "compacted-2", 10));
             results.element(6, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".2"));
@@ -311,7 +309,7 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
             // + 1 summary + 1 cleanup + 1 summary
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(18);
-            results.element(0, as(committableSummary())).hasPendingCommittables(14);
+            results.element(0, as(committableSummary()));
 
             List<FileSinkCommittable> expectedResult =
                     Arrays.asList(
@@ -335,11 +333,11 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
                         .hasCommittable(expectedResult.get(i));
             }
 
-            results.element(15, as(committableSummary())).hasPendingCommittables(1);
+            results.element(15, as(committableSummary()));
             results.element(16, as(committableWithLineage()))
                     .hasCommittable(cleanupPath("0", ".6"));
 
-            results.element(17, as(committableSummary())).hasPendingCommittables(3);
+            results.element(17, as(committableSummary()));
         }
     }
 
@@ -378,7 +376,7 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
 
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(3);
-            results.element(0, as(committableSummary())).hasPendingCommittables(4);
+            results.element(0, as(committableSummary()));
             results.element(1, as(committableWithLineage()))
                     .hasCommittable(committable("0", "compacted-1", 1));
             results.element(2, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".1"));
@@ -437,7 +435,7 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
 
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(2);
-            results.element(0, as(committableSummary())).hasPendingCommittables(1);
+            results.element(0, as(committableSummary()));
             results.element(1, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".2"));
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummary.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummary.java
@@ -39,11 +39,21 @@ public class CommittableSummary<CommT> implements CommittableMessage<CommT> {
     private final long checkpointId;
     /** The number of committables coming from the given subtask in the particular checkpoint. */
     private final int numberOfCommittables;
+
+    @Deprecated
     /** The number of committables that have not been successfully committed. */
     private final int numberOfPendingCommittables;
+
+    @Deprecated
     /** The number of committables that are not retried and have been failed. */
     private final int numberOfFailedCommittables;
 
+    public CommittableSummary(
+            int subtaskId, int numberOfSubtasks, long checkpointId, int numberOfCommittables) {
+        this(subtaskId, numberOfSubtasks, checkpointId, numberOfCommittables, 0, 0);
+    }
+
+    @Deprecated
     public CommittableSummary(
             int subtaskId,
             int numberOfSubtasks,
@@ -75,22 +85,19 @@ public class CommittableSummary<CommT> implements CommittableMessage<CommT> {
         return numberOfCommittables;
     }
 
+    @Deprecated
     public int getNumberOfPendingCommittables() {
-        return numberOfPendingCommittables;
+        return 0;
     }
 
+    @Deprecated
     public int getNumberOfFailedCommittables() {
-        return numberOfFailedCommittables;
+        return 0;
     }
 
     public <NewCommT> CommittableSummary<NewCommT> map() {
         return new CommittableSummary<>(
-                subtaskId,
-                numberOfSubtasks,
-                checkpointId,
-                numberOfCommittables,
-                numberOfPendingCommittables,
-                numberOfFailedCommittables);
+                subtaskId, numberOfSubtasks, checkpointId, numberOfCommittables);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -190,12 +190,7 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
         output.collect(
                 new StreamRecord<>(
                         new CommittableSummary<>(
-                                subtaskId,
-                                numberOfSubtasks,
-                                checkpointId,
-                                committables.size(),
-                                0,
-                                0)));
+                                subtaskId, numberOfSubtasks, checkpointId, committables.size())));
         for (CommT committable : committables) {
             output.collect(
                     new StreamRecord<>(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.metrics.groups.InternalSinkCommitterMetricGroup;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -66,7 +67,7 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
         implements OneInputStreamOperator<CommittableMessage<CommT>, CommittableMessage<CommT>>,
                 BoundedOneInput {
 
-    private static final long RETRY_DELAY = 1000;
+    private static final int MAX_RETRIES = 10;
     private final SimpleVersionedSerializer<CommT> committableSerializer;
     private final FunctionWithException<CommitterInitContext, Committer<CommT>, IOException>
             committerSupplier;
@@ -164,41 +165,42 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
 
     private void commitAndEmitCheckpoints() throws IOException, InterruptedException {
         long completedCheckpointId = endInput ? EOI : lastCompletedCheckpointId;
-        do {
-            for (CheckpointCommittableManager<CommT> manager :
-                    committableCollector.getCheckpointCommittablesUpTo(completedCheckpointId)) {
-                commitAndEmit(manager);
-            }
-            // !committableCollector.isFinished() indicates that we should retry
-            // Retry should be done here if this is a final checkpoint (indicated by endInput)
-            // WARN: this is an endless retry, may make the job stuck while finishing
-        } while (!committableCollector.isFinished() && endInput);
-
-        if (!committableCollector.isFinished()) {
-            // if not endInput, we can schedule retrying later
-            retryWithDelay();
+        for (CheckpointCommittableManager<CommT> checkpointManager :
+                committableCollector.getCheckpointCommittablesUpTo(completedCheckpointId)) {
+            // ensure that all committables of the first checkpoint are fully committed before
+            // attempting the next committable
+            commitAndEmit(checkpointManager);
+            committableCollector.remove(checkpointManager);
         }
-        committableCollector.compact();
     }
 
     private void commitAndEmit(CheckpointCommittableManager<CommT> committableManager)
             throws IOException, InterruptedException {
-        Collection<CommittableWithLineage<CommT>> committed = committableManager.commit(committer);
-        if (emitDownstream && committableManager.isFinished()) {
-            int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
-            int numberOfSubtasks = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
-            output.collect(
-                    new StreamRecord<>(committableManager.getSummary(subtaskId, numberOfSubtasks)));
-            for (CommittableWithLineage<CommT> committable : committed) {
-                output.collect(new StreamRecord<>(committable.withSubtaskId(subtaskId)));
-            }
+        committableManager.commit(committer, MAX_RETRIES);
+        if (emitDownstream) {
+            emit(committableManager);
         }
     }
 
-    private void retryWithDelay() {
-        processingTimeService.registerTimer(
-                processingTimeService.getCurrentProcessingTime() + RETRY_DELAY,
-                ts -> commitAndEmitCheckpoints());
+    private void emit(CheckpointCommittableManager<CommT> committableManager) {
+        int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
+        int numberOfSubtasks = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
+        long checkpointId = committableManager.getCheckpointId();
+        Collection<CommT> committables = committableManager.getSuccessfulCommittables();
+        output.collect(
+                new StreamRecord<>(
+                        new CommittableSummary<>(
+                                subtaskId,
+                                numberOfSubtasks,
+                                checkpointId,
+                                committables.size(),
+                                0,
+                                0)));
+        for (CommT committable : committables) {
+            output.collect(
+                    new StreamRecord<>(
+                            new CommittableWithLineage<>(committable, checkpointId, subtaskId)));
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
@@ -20,8 +20,6 @@ package org.apache.flink.streaming.runtime.operators.sink.committables;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.sink2.Committer;
-import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
-import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -50,12 +48,6 @@ public interface CheckpointCommittableManager<CommT> {
     /** Returns the number of upstream subtasks belonging to the checkpoint. */
     int getNumberOfSubtasks();
 
-    /**
-     * Returns a summary of the current commit progress for the emitting subtask identified by the
-     * parameters.
-     */
-    CommittableSummary<CommT> getSummary(int emittingSubtaskId, int emittingNumberOfSubtasks);
-
     boolean isFinished();
 
     /**
@@ -69,8 +61,10 @@ public interface CheckpointCommittableManager<CommT> {
      * checkpoint have been received.
      *
      * @param committer used to commit to the external system
-     * @return successfully committed committables with meta information
+     * @param maxRetries
      */
-    Collection<CommittableWithLineage<CommT>> commit(Committer<CommT> committer)
+    void commit(Committer<CommT> committer, int maxRetries)
             throws IOException, InterruptedException;
+
+    Collection<CommT> getSuccessfulCommittables();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImpl.java
@@ -127,24 +127,6 @@ class CheckpointCommittableManagerImpl<CommT> implements CheckpointCommittableMa
     }
 
     @Override
-    public CommittableSummary<CommT> getSummary(
-            int emittingSubtaskId, int emittingNumberOfSubtasks) {
-        return new CommittableSummary<>(
-                emittingSubtaskId,
-                emittingNumberOfSubtasks,
-                checkpointId,
-                subtasksCommittableManagers.values().stream()
-                        .mapToInt(SubtaskCommittableManager::getNumCommittables)
-                        .sum(),
-                subtasksCommittableManagers.values().stream()
-                        .mapToInt(SubtaskCommittableManager::getNumPending)
-                        .sum(),
-                subtasksCommittableManagers.values().stream()
-                        .mapToInt(SubtaskCommittableManager::getNumFailed)
-                        .sum());
-    }
-
-    @Override
     public boolean isFinished() {
         return subtasksCommittableManagers.values().stream()
                 .allMatch(SubtaskCommittableManager::isFinished);
@@ -158,20 +140,34 @@ class CheckpointCommittableManagerImpl<CommT> implements CheckpointCommittableMa
     }
 
     @Override
-    public Collection<CommittableWithLineage<CommT>> commit(Committer<CommT> committer)
+    public void commit(Committer<CommT> committer, int maxRetries)
             throws IOException, InterruptedException {
-        Collection<CommitRequestImpl<CommT>> requests = getPendingRequests(true);
-        requests.forEach(CommitRequestImpl::setSelected);
-        committer.commit(new ArrayList<>(requests));
-        requests.forEach(CommitRequestImpl::setCommittedIfNoError);
-        Collection<CommittableWithLineage<CommT>> committed = drainFinished();
-        metricGroup.setCurrentPendingCommittablesGauge(() -> getPendingRequests(false).size());
-        return committed;
+        Collection<CommitRequestImpl<CommT>> requests = getPendingRequests();
+        for (int retry = 0; !requests.isEmpty() && retry < maxRetries; retry++) {
+            requests.forEach(CommitRequestImpl::setSelected);
+            committer.commit(new ArrayList<>(requests));
+            requests.forEach(CommitRequestImpl::setCommittedIfNoError);
+            requests = requests.stream().filter(r -> !r.isFinished()).collect(Collectors.toList());
+            metricGroup.setCurrentPendingCommittablesGauge(requests::size);
+        }
+        if (!requests.isEmpty()) {
+            throw new IOException(
+                    String.format(
+                            "Failed to commit %s committables after %s retries: %s",
+                            requests.size(), maxRetries, requests));
+        }
     }
 
-    Collection<CommitRequestImpl<CommT>> getPendingRequests(boolean assertFull) {
+    @Override
+    public Collection<CommT> getSuccessfulCommittables() {
         return subtasksCommittableManagers.values().stream()
-                .peek(subtask -> assertReceivedAll(assertFull, subtask))
+                .flatMap(SubtaskCommittableManager::getSuccessfulCommittables)
+                .collect(Collectors.toList());
+    }
+
+    Collection<CommitRequestImpl<CommT>> getPendingRequests() {
+        return subtasksCommittableManagers.values().stream()
+                .peek(this::assertReceivedAll)
                 .flatMap(SubtaskCommittableManager::getPendingRequests)
                 .collect(Collectors.toList());
     }
@@ -192,18 +188,12 @@ class CheckpointCommittableManagerImpl<CommT> implements CheckpointCommittableMa
      * <p>This assertion will fail in case of bugs in the writer or in the pre-commit topology if
      * present.
      */
-    private void assertReceivedAll(boolean assertFull, SubtaskCommittableManager<CommT> subtask) {
+    private void assertReceivedAll(SubtaskCommittableManager<CommT> subtask) {
         Preconditions.checkArgument(
-                !assertFull || subtask.hasReceivedAll(),
+                subtask.hasReceivedAll(),
                 "Trying to commit incomplete batch of committables subtask=%s, manager=%s",
                 subtask.getSubtaskId(),
                 this);
-    }
-
-    Collection<CommittableWithLineage<CommT>> drainFinished() {
-        return subtasksCommittableManagers.values().stream()
-                .flatMap(subtask -> subtask.drainCommitted().stream())
-                .collect(Collectors.toList());
     }
 
     CheckpointCommittableManagerImpl<CommT> merge(CheckpointCommittableManagerImpl<CommT> other) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
@@ -208,9 +208,9 @@ public class CommittableCollector<CommT> {
         return checkNotNull(committables, "Unknown checkpoint for %s", committable);
     }
 
-    /** Removes all metadata about checkpoints of which all committables are fully committed. */
-    public void compact() {
-        checkpointCommittables.values().removeIf(CheckpointCommittableManagerImpl::isFinished);
+    /** Removes the manager for a specific checkpoint and all it's metadata. */
+    public void remove(CheckpointCommittableManager<CommT> manager) {
+        checkpointCommittables.remove(manager.getCheckpointId());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
@@ -145,17 +145,6 @@ public class CommittableCollector<CommT> {
     }
 
     /**
-     * Returns whether all {@link CheckpointCommittableManager} currently hold by the collector are
-     * either committed or failed.
-     *
-     * @return state of the {@link CheckpointCommittableManager}
-     */
-    public boolean isFinished() {
-        return checkpointCommittables.values().stream()
-                .allMatch(CheckpointCommittableManagerImpl::isFinished);
-    }
-
-    /**
      * Merges all information from an external collector into this collector.
      *
      * <p>This method is important during recovery from existing state.

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializer.java
@@ -207,7 +207,7 @@ public final class CommittableCollectorSerializer<CommT>
 
         @Override
         public int getVersion() {
-            return 1;
+            return 2;
         }
 
         @Override
@@ -219,8 +219,6 @@ public final class CommittableCollectorSerializer<CommT>
                     new ArrayList<>(subtask.getRequests()),
                     out);
             out.writeInt(subtask.getNumCommittables());
-            out.writeInt(subtask.getNumDrained());
-            out.writeInt(subtask.getNumFailed());
             return out.getCopyOfBuffer();
         }
 
@@ -236,8 +234,8 @@ public final class CommittableCollectorSerializer<CommT>
             return new SubtaskCommittableManager<>(
                     requests,
                     in.readInt(),
-                    in.readInt(),
-                    in.readInt(),
+                    version >= 2 ? 0 : in.readInt(),
+                    version >= 2 ? 0 : in.readInt(),
                     subtaskId,
                     checkNotNull(
                             checkpointId,

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.streaming.runtime.operators.sink.committables.CommitRequestState.COMMITTED;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -138,6 +139,12 @@ class SubtaskCommittableManager<CommT> {
         return requests.stream().filter(c -> !c.isFinished());
     }
 
+    Stream<CommT> getSuccessfulCommittables() {
+        return getRequests().stream()
+                .filter(c -> c.getState() == COMMITTED)
+                .map(CommitRequestImpl::getCommittable);
+    }
+
     /**
      * Iterates through all currently registered {@link #requests} and returns all {@link
      * CommittableWithLineage} that could be successfully committed.
@@ -184,7 +191,7 @@ class SubtaskCommittableManager<CommT> {
         return checkpointId;
     }
 
-    Deque<CommitRequestImpl<CommT>> getRequests() {
+    Collection<CommitRequestImpl<CommT>> getRequests() {
         return requests;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
@@ -25,12 +25,9 @@ import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.shaded.guava32.com.google.common.collect.Iterables;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -46,8 +43,8 @@ class SubtaskCommittableManager<CommT> {
     private final int numExpectedCommittables;
     private final long checkpointId;
     private final int subtaskId;
-    private int numDrained;
-    private int numFailed;
+    @Deprecated private int numDrained;
+    @Deprecated private int numFailed;
     private final SinkCommitterMetricGroup metricGroup;
 
     SubtaskCommittableManager(
@@ -65,6 +62,20 @@ class SubtaskCommittableManager<CommT> {
                 metricGroup);
     }
 
+    SubtaskCommittableManager(
+            Collection<CommitRequestImpl<CommT>> requests,
+            int numExpectedCommittables,
+            int subtaskId,
+            long checkpointId,
+            SinkCommitterMetricGroup metricGroup) {
+        this.checkpointId = checkpointId;
+        this.subtaskId = subtaskId;
+        this.numExpectedCommittables = numExpectedCommittables;
+        this.requests = new ArrayDeque<>(checkNotNull(requests));
+        this.metricGroup = metricGroup;
+    }
+
+    @Deprecated
     SubtaskCommittableManager(
             Collection<CommitRequestImpl<CommT>> requests,
             int numExpectedCommittables,
@@ -107,26 +118,11 @@ class SubtaskCommittableManager<CommT> {
      * @return number of so far received committables
      */
     int getNumCommittables() {
-        return requests.size() + numDrained + numFailed;
-    }
-
-    /**
-     * Returns the number of still expected commits.
-     *
-     * <p>Either the committables are not yet received or the commit is still pending.
-     *
-     * @return number of still expected committables
-     */
-    int getNumPending() {
-        return numExpectedCommittables - (numDrained + numFailed);
-    }
-
-    int getNumFailed() {
-        return numFailed;
+        return requests.size();
     }
 
     boolean isFinished() {
-        return getNumPending() == 0;
+        return getPendingRequests().findAny().isEmpty();
     }
 
     /**
@@ -143,43 +139,6 @@ class SubtaskCommittableManager<CommT> {
         return getRequests().stream()
                 .filter(c -> c.getState() == COMMITTED)
                 .map(CommitRequestImpl::getCommittable);
-    }
-
-    /**
-     * Iterates through all currently registered {@link #requests} and returns all {@link
-     * CommittableWithLineage} that could be successfully committed.
-     *
-     * <p>Invoking this method does not yield the same {@link CommittableWithLineage} again. Once
-     * retrieved they are not part of {@link #requests} anymore.
-     *
-     * @return list of {@link CommittableWithLineage}
-     */
-    List<CommittableWithLineage<CommT>> drainCommitted() {
-        List<CommittableWithLineage<CommT>> committed = new ArrayList<>(requests.size());
-        for (Iterator<CommitRequestImpl<CommT>> iterator = requests.iterator();
-                iterator.hasNext(); ) {
-            CommitRequestImpl<CommT> request = iterator.next();
-            if (!request.isFinished()) {
-                continue;
-            }
-            if (request.getState() == CommitRequestState.FAILED) {
-                numFailed += 1;
-                iterator.remove();
-                continue;
-            } else {
-                committed.add(
-                        new CommittableWithLineage<>(
-                                request.getCommittable(), checkpointId, subtaskId));
-            }
-            iterator.remove();
-        }
-
-        numDrained += committed.size();
-        return committed;
-    }
-
-    int getNumDrained() {
-        return numDrained;
     }
 
     int getSubtaskId() {
@@ -202,8 +161,6 @@ class SubtaskCommittableManager<CommT> {
                 Stream.concat(requests.stream(), other.requests.stream())
                         .collect(Collectors.toList()),
                 numExpectedCommittables + other.numExpectedCommittables,
-                numDrained + other.numDrained,
-                numFailed + other.numFailed,
                 subtaskId,
                 checkpointId,
                 metricGroup);
@@ -213,8 +170,6 @@ class SubtaskCommittableManager<CommT> {
         return new SubtaskCommittableManager<>(
                 requests.stream().map(CommitRequestImpl::copy).collect(Collectors.toList()),
                 numExpectedCommittables,
-                numDrained,
-                numFailed,
                 subtaskId,
                 checkpointId,
                 metricGroup);
@@ -232,15 +187,12 @@ class SubtaskCommittableManager<CommT> {
         return numExpectedCommittables == that.numExpectedCommittables
                 && checkpointId == that.checkpointId
                 && subtaskId == that.subtaskId
-                && numDrained == that.numDrained
-                && numFailed == that.numFailed
                 && Iterables.elementsEqual(requests, that.requests);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-                requests, numExpectedCommittables, checkpointId, subtaskId, numDrained, numFailed);
+        return Objects.hash(requests, numExpectedCommittables, checkpointId, subtaskId);
     }
 
     @Override
@@ -254,10 +206,6 @@ class SubtaskCommittableManager<CommT> {
                 + checkpointId
                 + ", subtaskId="
                 + subtaskId
-                + ", numDrained="
-                + numDrained
-                + ", numFailed="
-                + numFailed
                 + '}';
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableMessageSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableMessageSerializerTest.java
@@ -47,7 +47,7 @@ class CommittableMessageSerializerTest {
     @Test
     void testCommittableSummarySerDe() throws IOException {
         final CommittableSummary<Integer> committableSummary =
-                new CommittableSummary<>(1, 2, 3L, 4, 5, 6);
+                new CommittableSummary<>(1, 2, 3L, 4);
         final CommittableMessage<Integer> message =
                 SERIALIZER.deserialize(
                         CommittableMessageSerializer.VERSION,
@@ -58,7 +58,5 @@ class CommittableMessageSerializerTest {
         assertThat(copy.getNumberOfSubtasks()).isEqualTo(2);
         assertThat(copy.getCheckpointIdOrEOI()).isEqualTo(3L);
         assertThat(copy.getNumberOfCommittables()).isEqualTo(4);
-        assertThat(copy.getNumberOfPendingCommittables()).isEqualTo(5);
-        assertThat(copy.getNumberOfFailedCommittables()).isEqualTo(6);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummaryAssert.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummaryAssert.java
@@ -40,14 +40,6 @@ public class CommittableSummaryAssert<CommT>
         return returns(committableNumber, CommittableSummary::getNumberOfCommittables);
     }
 
-    public CommittableSummaryAssert<CommT> hasPendingCommittables(int committableNumber) {
-        return returns(committableNumber, CommittableSummary::getNumberOfPendingCommittables);
-    }
-
-    public CommittableSummaryAssert<CommT> hasFailedCommittables(int committableNumber) {
-        return returns(committableNumber, CommittableSummary::getNumberOfFailedCommittables);
-    }
-
     public CommittableSummaryAssert<CommT> hasCheckpointId(long checkpointId) {
         return returns(checkpointId, CommittableSummary::getCheckpointIdOrEOI);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
@@ -63,6 +63,7 @@ class GlobalCommitterOperatorTest {
             if (commitOnInput) {
                 assertThat(committer.committed).containsExactly(1, 2);
             } else {
+                // 3PC behavior
                 assertThat(committer.committed).isEmpty();
                 testHarness.notifyOfCompletedCheckpoint(cid + 1);
                 assertThat(committer.committed).containsExactly(1, 2);

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
@@ -47,8 +47,7 @@ class GlobalCommitterOperatorTest {
             testHarness.open();
 
             long cid = 1L;
-            testHarness.processElement(
-                    new StreamRecord<>(new CommittableSummary<>(1, 1, cid, 2, 0, 0)));
+            testHarness.processElement(new StreamRecord<>(new CommittableSummary<>(1, 1, cid, 2)));
 
             testHarness.processElement(new StreamRecord<>(new CommittableWithLineage<>(1, cid, 1)));
 
@@ -63,7 +62,6 @@ class GlobalCommitterOperatorTest {
             if (commitOnInput) {
                 assertThat(committer.committed).containsExactly(1, 2);
             } else {
-                // 3PC behavior
                 assertThat(committer.committed).isEmpty();
                 testHarness.notifyOfCompletedCheckpoint(cid + 1);
                 assertThat(committer.committed).containsExactly(1, 2);
@@ -82,8 +80,7 @@ class GlobalCommitterOperatorTest {
             testHarness.open();
 
             long cid = 1L;
-            testHarness.processElement(
-                    new StreamRecord<>(new CommittableSummary<>(1, 1, cid, 2, 0, 0)));
+            testHarness.processElement(new StreamRecord<>(new CommittableSummary<>(1, 1, cid, 2)));
 
             testHarness.processElement(new StreamRecord<>(new CommittableWithLineage<>(1, cid, 1)));
 
@@ -116,7 +113,7 @@ class GlobalCommitterOperatorTest {
             testHarness.open();
 
             final CommittableSummary<Integer> committableSummary =
-                    new CommittableSummary<>(1, 1, 0L, 1, 1, 0);
+                    new CommittableSummary<>(1, 1, 0L, 1);
             testHarness.processElement(new StreamRecord<>(committableSummary));
             final CommittableWithLineage<Integer> first = new CommittableWithLineage<>(1, 0L, 1);
             testHarness.processElement(new StreamRecord<>(first));
@@ -147,10 +144,10 @@ class GlobalCommitterOperatorTest {
         testHarness.open();
 
         final CommittableSummary<Integer> committableSummary =
-                new CommittableSummary<>(1, 2, EOI, 1, 1, 0);
+                new CommittableSummary<>(1, 2, EOI, 1);
         testHarness.processElement(new StreamRecord<>(committableSummary));
         final CommittableSummary<Integer> committableSummary2 =
-                new CommittableSummary<>(2, 2, EOI, 1, 1, 0);
+                new CommittableSummary<>(2, 2, EOI, 1);
         testHarness.processElement(new StreamRecord<>(committableSummary2));
 
         final CommittableWithLineage<Integer> first = new CommittableWithLineage<>(1, EOI, 1);

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterSerializerTest.java
@@ -70,7 +70,6 @@ class GlobalCommitterSerializerTest {
         final GlobalCommittableWrapper<Integer, String> copy =
                 serializer.deserialize(2, serializer.serialize(wrapper));
         assertThat(copy.getGlobalCommittables()).containsExactlyInAnyOrderElementsOf(v1State);
-        assertThat(collector).returns(false, CommittableCollector::isFinished);
         assertThat(collector.getCheckpointCommittablesUpTo(2))
                 .singleElement()
                 .returns(1L, CheckpointCommittableManager::getCheckpointId)

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImplTest.java
@@ -48,17 +48,15 @@ class CheckpointCommittableManagerImplTest {
                 new CheckpointCommittableManagerImpl<>(new HashMap<>(), 1, 1L, METRIC_GROUP);
         assertThat(checkpointCommittables.getSubtaskCommittableManagers()).isEmpty();
 
-        final CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1, 0, 0);
+        final CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1);
         checkpointCommittables.addSummary(first);
         assertThat(checkpointCommittables.getSubtaskCommittableManagers())
                 .singleElement()
                 .returns(1, SubtaskCommittableManager::getSubtaskId)
-                .returns(1L, SubtaskCommittableManager::getCheckpointId)
-                .returns(1, SubtaskCommittableManager::getNumPending)
-                .returns(0, SubtaskCommittableManager::getNumFailed);
+                .returns(1L, SubtaskCommittableManager::getCheckpointId);
 
         // Add different subtask id
-        final CommittableSummary<Integer> third = new CommittableSummary<>(2, 1, 2L, 2, 1, 1);
+        final CommittableSummary<Integer> third = new CommittableSummary<>(2, 1, 2L, 2);
         checkpointCommittables.addSummary(third);
         assertThat(checkpointCommittables.getSubtaskCommittableManagers()).hasSize(2);
     }
@@ -67,8 +65,8 @@ class CheckpointCommittableManagerImplTest {
     void testCommit() throws IOException, InterruptedException {
         final CheckpointCommittableManagerImpl<Integer> checkpointCommittables =
                 new CheckpointCommittableManagerImpl<>(new HashMap<>(), 1, 1L, METRIC_GROUP);
-        checkpointCommittables.addSummary(new CommittableSummary<>(1, 1, 1L, 1, 0, 0));
-        checkpointCommittables.addSummary(new CommittableSummary<>(2, 1, 1L, 2, 0, 0));
+        checkpointCommittables.addSummary(new CommittableSummary<>(1, 1, 1L, 1));
+        checkpointCommittables.addSummary(new CommittableSummary<>(2, 1, 1L, 2));
         checkpointCommittables.addCommittable(new CommittableWithLineage<>(3, 1L, 1));
         checkpointCommittables.addCommittable(new CommittableWithLineage<>(4, 1L, 2));
 
@@ -95,11 +93,11 @@ class CheckpointCommittableManagerImplTest {
     void testUpdateCommittableSummary() {
         final CheckpointCommittableManagerImpl<Integer> checkpointCommittables =
                 new CheckpointCommittableManagerImpl<>(new HashMap<>(), 1, 1L, METRIC_GROUP);
-        checkpointCommittables.addSummary(new CommittableSummary<>(1, 1, 1L, 1, 0, 0));
+        checkpointCommittables.addSummary(new CommittableSummary<>(1, 1, 1L, 1));
         assertThatThrownBy(
                         () ->
                                 checkpointCommittables.addSummary(
-                                        new CommittableSummary<>(1, 1, 1L, 2, 0, 0)))
+                                        new CommittableSummary<>(1, 1, 1L, 2)))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("FLINK-25920");
     }
@@ -113,8 +111,7 @@ class CheckpointCommittableManagerImplTest {
         final CheckpointCommittableManagerImpl<Integer> original =
                 new CheckpointCommittableManagerImpl<>(
                         new HashMap<>(), numberOfSubtasks, checkpointId, METRIC_GROUP);
-        original.addSummary(
-                new CommittableSummary<>(subtaskId, numberOfSubtasks, checkpointId, 1, 0, 0));
+        original.addSummary(new CommittableSummary<>(subtaskId, numberOfSubtasks, checkpointId, 1));
 
         CheckpointCommittableManagerImpl<Integer> copy = original.copy();
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.api.connector.sink2.IntegerSerializer;
-import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
@@ -205,11 +204,10 @@ class CommittableCollectorSerializerTest {
                                     checkpointCommittableManager.getSubtaskCommittableManager(
                                             subtaskId);
 
-                            SinkV2Assertions.assertThat(
-                                            checkpointCommittableManager.getSummary(
-                                                    subtaskId, numberOfSubtasks))
-                                    .hasSubtaskId(subtaskId)
-                                    .hasNumberOfSubtasks(numberOfSubtasks);
+                            assertThat(checkpointCommittableManager)
+                                    .returns(
+                                            numberOfSubtasks,
+                                            CheckpointCommittableManagerImpl::getNumberOfSubtasks);
 
                             assertPendingRequests(
                                     subtaskCommittableManager, expectedPendingRequestCount);

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
@@ -63,8 +63,6 @@ class CommittableCollectorSerializerTest {
         final CommittableCollector<Integer> committableCollector =
                 SERIALIZER.deserialize(1, serialized);
 
-        assertThat(committableCollector.isFinished()).isFalse();
-
         assertThat(committableCollector.getCheckpointCommittables())
                 .singleElement()
                 .extracting(
@@ -89,17 +87,14 @@ class CommittableCollectorSerializerTest {
         final CommittableCollector<Integer> committableCollector =
                 new CommittableCollector<>(METRIC_GROUP);
         committableCollector.addMessage(
-                new CommittableSummary<>(subtaskId, numberOfSubtasks, 1L, 1, 1, 0));
+                new CommittableSummary<>(subtaskId, numberOfSubtasks, 1L, 1));
         committableCollector.addMessage(
-                new CommittableSummary<>(subtaskId, numberOfSubtasks, 2L, 1, 1, 0));
+                new CommittableSummary<>(subtaskId, numberOfSubtasks, 2L, 1));
         committableCollector.addMessage(new CommittableWithLineage<>(1, 1L, subtaskId));
         committableCollector.addMessage(new CommittableWithLineage<>(2, 2L, subtaskId));
 
         final CommittableCollector<Integer> copy =
                 ccSerializer.deserialize(2, SERIALIZER.serialize(committableCollector));
-
-        // Expect the subtask Id equal to the origin of the collector
-        assertThat(copy.isFinished()).isFalse();
 
         // assert original CommittableCollector
         assertCommittableCollector(
@@ -139,9 +134,6 @@ class CommittableCollectorSerializerTest {
 
         final CommittableCollector<Integer> copy =
                 ccSerializer.deserialize(2, SERIALIZER.serialize(committableCollector));
-
-        // Expect the subtask Id equal to the origin of the collector
-        assertThat(copy.isFinished()).isFalse();
 
         // assert original CommittableCollector
         assertCommittableCollector(

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.operators.sink.committables;
 import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
-import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,7 +58,8 @@ class CommittableCollectorTest {
         Optional<CheckpointCommittableManager<Integer>> endOfInputCommittable =
                 committableCollector.getEndOfInputCommittable();
         assertThat(endOfInputCommittable).isPresent();
-        SinkV2Assertions.assertThat(endOfInputCommittable.get().getSummary(1, 1))
-                .hasCheckpointId(EOI);
+        assertThat(endOfInputCommittable)
+                .get()
+                .returns(EOI, CheckpointCommittableManager::getCheckpointId);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
@@ -37,11 +37,11 @@ class CommittableCollectorTest {
     void testGetCheckpointCommittablesUpTo() {
         final CommittableCollector<Integer> committableCollector =
                 new CommittableCollector<>(METRIC_GROUP);
-        CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1, 0, 0);
+        CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1);
         committableCollector.addMessage(first);
-        CommittableSummary<Integer> second = new CommittableSummary<>(1, 1, 2L, 1, 0, 0);
+        CommittableSummary<Integer> second = new CommittableSummary<>(1, 1, 2L, 1);
         committableCollector.addMessage(second);
-        committableCollector.addMessage(new CommittableSummary<>(1, 1, 3L, 1, 0, 0));
+        committableCollector.addMessage(new CommittableSummary<>(1, 1, 3L, 1));
 
         assertThat(committableCollector.getCheckpointCommittablesUpTo(2)).hasSize(2);
 
@@ -52,7 +52,7 @@ class CommittableCollectorTest {
     void testGetEndOfInputCommittable() {
         final CommittableCollector<Integer> committableCollector =
                 new CommittableCollector<>(METRIC_GROUP);
-        CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, EOI, 1, 0, 0);
+        CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, EOI, 1);
         committableCollector.addMessage(first);
 
         Optional<CheckpointCommittableManager<Integer>> endOfInputCommittable =

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManagerTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 
-import org.assertj.core.api.ListAssert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -30,8 +29,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions.committableWithLineage;
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SubtaskCommittableManagerTest {
@@ -39,7 +36,7 @@ class SubtaskCommittableManagerTest {
             MetricsGroupTestUtils.mockCommitterMetricGroup();
 
     @Test
-    void testDrainCommittables() {
+    void testSuccessfulCommittables() {
         final SubtaskCommittableManager<Integer> subtaskCommittableManager =
                 new SubtaskCommittableManager<>(3, 1, 1L, METRIC_GROUP);
         final CommittableWithLineage<Integer> first = new CommittableWithLineage<>(1, 1L, 1);
@@ -54,7 +51,6 @@ class SubtaskCommittableManagerTest {
         subtaskCommittableManager.add(third);
         assertThat(subtaskCommittableManager.getPendingRequests()).hasSize(3);
         assertThat(subtaskCommittableManager.getNumCommittables()).isEqualTo(3);
-        assertThat(subtaskCommittableManager.getNumDrained()).isEqualTo(0);
         assertThat(subtaskCommittableManager.isFinished()).isFalse();
 
         // Trigger commit
@@ -63,36 +59,18 @@ class SubtaskCommittableManagerTest {
         IntStream.range(0, 2).forEach(i -> requests.next().setCommittedIfNoError());
         assertThat(subtaskCommittableManager.getPendingRequests()).hasSize(1);
         assertThat(subtaskCommittableManager.getNumCommittables()).isEqualTo(3);
-        assertThat(subtaskCommittableManager.getNumDrained()).isEqualTo(0);
 
-        // Drain committed committables
-        ListAssert<CommittableWithLineage<Integer>> committables =
-                assertThat(subtaskCommittableManager.drainCommitted()).hasSize(2);
-        committables
-                .element(0, as(committableWithLineage()))
-                .hasSubtaskId(1)
-                .hasCommittable(1)
-                .hasCheckpointId(1);
-        committables
-                .element(1, as(committableWithLineage()))
-                .hasSubtaskId(1)
-                .hasCommittable(2)
-                .hasCheckpointId(1);
-        assertThat(subtaskCommittableManager.getNumFailed()).isEqualTo(0);
-
-        // Drain again should not yield anything
-        assertThat(subtaskCommittableManager.drainCommitted()).hasSize(0);
+        // Check the successful committables
+        assertThat(subtaskCommittableManager.getSuccessfulCommittables())
+                .containsExactlyInAnyOrder(1, 2);
 
         // Fail commit
         requests.next().signalFailedWithKnownReason(new RuntimeException("Unused exception"));
-        assertThat(subtaskCommittableManager.getNumFailed()).isEqualTo(0);
         assertThat(subtaskCommittableManager.getPendingRequests()).hasSize(0);
         assertThat(subtaskCommittableManager.getNumCommittables()).isEqualTo(3);
-        assertThat(subtaskCommittableManager.isFinished()).isFalse();
-
-        // Drain to update fail count
-        assertThat(subtaskCommittableManager.drainCommitted()).hasSize(0);
-        assertThat(subtaskCommittableManager.getNumFailed()).isEqualTo(1);
+        // doesn't change the successful committables
+        assertThat(subtaskCommittableManager.getSuccessfulCommittables())
+                .containsExactlyInAnyOrder(1, 2);
         assertThat(subtaskCommittableManager.isFinished()).isTrue();
     }
 
@@ -103,8 +81,6 @@ class SubtaskCommittableManagerTest {
                         Collections.singletonList(new CommitRequestImpl<>(1, METRIC_GROUP)),
                         5,
                         1,
-                        2,
-                        1,
                         2L,
                         METRIC_GROUP);
         SubtaskCommittableManager<Integer> merged =
@@ -114,15 +90,11 @@ class SubtaskCommittableManagerTest {
                                         new CommitRequestImpl<>(2, METRIC_GROUP),
                                         new CommitRequestImpl<>(3, METRIC_GROUP)),
                                 10,
-                                2,
-                                3,
                                 1,
                                 2L,
                                 METRIC_GROUP));
         assertThat(merged.getNumCommittables()).isEqualTo(11);
-        assertThat(merged.getNumDrained()).isEqualTo(3);
         assertThat(merged.isFinished()).isFalse();
-        assertThat(merged.getNumFailed()).isEqualTo(5);
         assertThat(merged.getPendingRequests()).hasSize(3);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorTestBase.java
@@ -203,7 +203,8 @@ abstract class CommitterOperatorTestBase {
         final OperatorSubtaskState snapshot = testHarness.snapshot(checkpointId, 2L);
 
         // Trigger first checkpoint but committer needs retry
-        testHarness.notifyOfCompletedCheckpoint(0);
+        assertThatCode(() -> testHarness.notifyOfCompletedCheckpoint(0))
+                .hasMessageContaining("Failed to commit 2 committables");
 
         assertThat(testHarness.getOutput()).isEmpty();
         testHarness.close();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorTestBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummaryAssert;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -59,8 +60,7 @@ abstract class CommitterOperatorTestBase {
                                 new CommitterOperatorFactory<>(sinkAndCounters.sink, false, true));
         testHarness.open();
 
-        final CommittableSummary<String> committableSummary =
-                new CommittableSummary<>(1, 1, 1L, 1, 1, 0);
+        final CommittableSummary<String> committableSummary = new CommittableSummary<>(1, 1, 1L, 1);
         testHarness.processElement(new StreamRecord<>(committableSummary));
         final CommittableWithLineage<String> committableWithLineage =
                 new CommittableWithLineage<>("1", 1L, 1);
@@ -74,9 +74,7 @@ abstract class CommitterOperatorTestBase {
             ListAssert<CommittableMessage<String>> records =
                     assertThat(testHarness.extractOutputValues()).hasSize(2);
             records.element(0, as(committableSummary()))
-                    .hasFailedCommittables(committableSummary.getNumberOfFailedCommittables())
-                    .hasOverallCommittables(committableSummary.getNumberOfCommittables())
-                    .hasPendingCommittables(0);
+                    .hasOverallCommittables(committableSummary.getNumberOfCommittables());
             records.element(1, as(committableWithLineage()))
                     .isEqualTo(committableWithLineage.withSubtaskId(0));
         } else {
@@ -95,8 +93,7 @@ abstract class CommitterOperatorTestBase {
         testHarness.setProcessingTime(0);
 
         // Only send first committable
-        final CommittableSummary<String> committableSummary =
-                new CommittableSummary<>(1, 1, 1L, 2, 2, 0);
+        final CommittableSummary<String> committableSummary = new CommittableSummary<>(1, 1, 1L, 2);
         testHarness.processElement(new StreamRecord<>(committableSummary));
         final CommittableWithLineage<String> first = new CommittableWithLineage<>("1", 1L, 1);
         testHarness.processElement(new StreamRecord<>(first));
@@ -116,9 +113,7 @@ abstract class CommitterOperatorTestBase {
         ListAssert<CommittableMessage<String>> records =
                 assertThat(testHarness.extractOutputValues()).hasSize(3);
         records.element(0, as(committableSummary()))
-                .hasFailedCommittables(committableSummary.getNumberOfFailedCommittables())
-                .hasOverallCommittables(committableSummary.getNumberOfCommittables())
-                .hasPendingCommittables(0);
+                .hasOverallCommittables(committableSummary.getNumberOfCommittables());
         records.element(1, as(committableWithLineage())).isEqualTo(first.withSubtaskId(0));
         records.element(2, as(committableWithLineage())).isEqualTo(second.withSubtaskId(0));
         testHarness.close();
@@ -134,10 +129,10 @@ abstract class CommitterOperatorTestBase {
         testHarness.open();
 
         final CommittableSummary<String> committableSummary =
-                new CommittableSummary<>(1, 2, EOI, 1, 1, 0);
+                new CommittableSummary<>(1, 2, EOI, 1);
         testHarness.processElement(new StreamRecord<>(committableSummary));
         final CommittableSummary<String> committableSummary2 =
-                new CommittableSummary<>(2, 2, EOI, 1, 1, 0);
+                new CommittableSummary<>(2, 2, EOI, 1);
         testHarness.processElement(new StreamRecord<>(committableSummary2));
 
         final CommittableWithLineage<String> first = new CommittableWithLineage<>("1", EOI, 1);
@@ -154,10 +149,7 @@ abstract class CommitterOperatorTestBase {
 
         ListAssert<CommittableMessage<String>> records =
                 assertThat(testHarness.extractOutputValues()).hasSize(3);
-        records.element(0, as(committableSummary()))
-                .hasFailedCommittables(0)
-                .hasOverallCommittables(2)
-                .hasPendingCommittables(0);
+        records.element(0, as(committableSummary())).hasOverallCommittables(2);
         records.element(1, as(committableWithLineage())).isEqualTo(first.withSubtaskId(0));
         records.element(2, as(committableWithLineage())).isEqualTo(second.withSubtaskId(0));
         testHarness.close();
@@ -186,7 +178,7 @@ abstract class CommitterOperatorTestBase {
         long checkpointId = 0L;
 
         final CommittableSummary<String> committableSummary =
-                new CommittableSummary<>(originalSubtaskId, 1, checkpointId, 1, 1, 0);
+                new CommittableSummary<>(originalSubtaskId, 1, checkpointId, 1);
         testHarness.processElement(new StreamRecord<>(committableSummary));
         final CommittableWithLineage<String> first =
                 new CommittableWithLineage<>("1", checkpointId, originalSubtaskId);
@@ -194,7 +186,7 @@ abstract class CommitterOperatorTestBase {
 
         // another committable for the same checkpointId but from different subtask.
         final CommittableSummary<String> committableSummary2 =
-                new CommittableSummary<>(originalSubtaskId + 1, 1, checkpointId, 1, 1, 0);
+                new CommittableSummary<>(originalSubtaskId + 1, 1, checkpointId, 1);
         testHarness.processElement(new StreamRecord<>(committableSummary2));
         final CommittableWithLineage<String> second =
                 new CommittableWithLineage<>("2", checkpointId, originalSubtaskId + 1);
@@ -226,12 +218,11 @@ abstract class CommitterOperatorTestBase {
         assertThat(sinkAndCounters.commitCounter.getAsInt()).isEqualTo(2);
         ListAssert<CommittableMessage<String>> records =
                 assertThat(restored.extractOutputValues()).hasSize(3);
-        records.element(0, as(committableSummary()))
-                .hasCheckpointId(checkpointId)
-                .hasSubtaskId(subtaskIdAfterRecovery)
-                .hasFailedCommittables(0)
-                .hasOverallCommittables(2)
-                .hasPendingCommittables(0);
+        CommittableSummaryAssert<Object> objectCommittableSummaryAssert =
+                records.element(0, as(committableSummary()))
+                        .hasCheckpointId(checkpointId)
+                        .hasSubtaskId(subtaskIdAfterRecovery);
+        objectCommittableSummaryAssert.hasOverallCommittables(2);
 
         // Expect the same checkpointId that the original snapshot was made with.
         records.element(1, as(committableWithLineage()))
@@ -250,44 +241,43 @@ abstract class CommitterOperatorTestBase {
     void testHandleEndInputInStreamingMode(boolean isCheckpointingEnabled) throws Exception {
         final SinkAndCounters sinkAndCounters = sinkWithPostCommit();
 
-        final OneInputStreamOperatorTestHarness<
+        try (OneInputStreamOperatorTestHarness<
                         CommittableMessage<String>, CommittableMessage<String>>
                 testHarness =
                         new OneInputStreamOperatorTestHarness<>(
                                 new CommitterOperatorFactory<>(
-                                        sinkAndCounters.sink, false, isCheckpointingEnabled));
-        testHarness.open();
+                                        sinkAndCounters.sink, false, isCheckpointingEnabled))) {
+            testHarness.open();
 
-        final CommittableSummary<String> committableSummary =
-                new CommittableSummary<>(1, 1, 1L, 1, 1, 0);
-        testHarness.processElement(new StreamRecord<>(committableSummary));
-        final CommittableWithLineage<String> committableWithLineage =
-                new CommittableWithLineage<>("1", 1L, 1);
-        testHarness.processElement(new StreamRecord<>(committableWithLineage));
+            final CommittableSummary<String> committableSummary =
+                    new CommittableSummary<>(1, 1, 1L, 1);
+            testHarness.processElement(new StreamRecord<>(committableSummary));
+            final CommittableWithLineage<String> committableWithLineage =
+                    new CommittableWithLineage<>("1", 1L, 1);
+            testHarness.processElement(new StreamRecord<>(committableWithLineage));
 
-        testHarness.endInput();
+            testHarness.endInput();
 
-        // If checkpointing enabled endInput does not emit anything because a final checkpoint
-        // follows
-        if (isCheckpointingEnabled) {
-            testHarness.notifyOfCompletedCheckpoint(1);
+            // If checkpointing enabled endInput does not emit anything because a final checkpoint
+            // follows
+            if (isCheckpointingEnabled) {
+                testHarness.notifyOfCompletedCheckpoint(1);
+            }
+
+            ListAssert<CommittableMessage<String>> records =
+                    assertThat(testHarness.extractOutputValues()).hasSize(2);
+            CommittableSummaryAssert<Object> objectCommittableSummaryAssert =
+                    records.element(0, as(committableSummary())).hasCheckpointId(1L);
+            objectCommittableSummaryAssert.hasOverallCommittables(1);
+            records.element(1, as(committableWithLineage()))
+                    .isEqualTo(committableWithLineage.withSubtaskId(0));
+
+            // Future emission calls should change the output
+            testHarness.notifyOfCompletedCheckpoint(2);
+            testHarness.endInput();
+
+            assertThat(testHarness.getOutput()).hasSize(2);
         }
-
-        ListAssert<CommittableMessage<String>> records =
-                assertThat(testHarness.extractOutputValues()).hasSize(2);
-        records.element(0, as(committableSummary()))
-                .hasCheckpointId(1L)
-                .hasPendingCommittables(0)
-                .hasOverallCommittables(1)
-                .hasFailedCommittables(0);
-        records.element(1, as(committableWithLineage()))
-                .isEqualTo(committableWithLineage.withSubtaskId(0));
-
-        // Future emission calls should change the output
-        testHarness.notifyOfCompletedCheckpoint(2);
-        testHarness.endInput();
-
-        assertThat(testHarness.getOutput()).hasSize(2);
     }
 
     private OneInputStreamOperatorTestHarness<


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Sinks so far retried asynchronously to increase commit throughput in case of temporary issues. However, the contract of notifyCheckpointCompleted states that checkpoints must be side-effect free meaning all transactions have to be committed on return of the PRC call.

## Brief change log


* This commit retries a fixed number of times and then fails in notifyCheckpointCompleted.
* Simplifies parts of committable handling now that all committables of a subtask either succeed or fail


## Verifying this change

* Already covered by many tests
* Adjusted and changed tests in
api/connector/sink2
runtime/operators/sink/committables

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
